### PR TITLE
Fix CSV parsing for owners and accommodations

### DIFF
--- a/app/api/upload-accommodations/route.js
+++ b/app/api/upload-accommodations/route.js
@@ -57,7 +57,7 @@ export async function POST(req) {
           referenceCadastrale: row['Référence cadastrale'],
         };
       },
-      ','
+      ';'
     );
 
     // Filtrer les lignes nulles

--- a/app/lib/parseCsvBuffer.js
+++ b/app/lib/parseCsvBuffer.js
@@ -22,7 +22,7 @@ export async function parseCsvBuffer(
     delimiter,
     relax_column_count: true,
     skip_records_with_error: true,
-    from_line: 3,           // ← Commence à la 3e ligne (header CSV correct)
+    from_line: 2,           // ← Commence à la 2e ligne (1 ligne d'introduction)
   });
 
   const stream = Readable.from(buffer).pipe(parser);


### PR DESCRIPTION
## Summary
- adjust `parseCsvBuffer` to start reading on the second line
- use the correct `;` delimiter when parsing accommodations uploads

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854e62b3828832eb493ccdb50b27975