### PR TITLE
Add versement table page

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -27,8 +27,11 @@ export default function RootLayout({ children }) {
           <Link href="/" className="mr-4 hover:underline">
             Accueil
           </Link>
-          <Link href="/taxe-de-sejour" className="hover:underline">
+          <Link href="/taxe-de-sejour" className="mr-4 hover:underline">
             Taxe de Séjour
+          </Link>
+          <Link href="/versement" className="hover:underline">
+            Versement
           </Link>
         </nav>
         {children}

--- a/app/versement/page.js
+++ b/app/versement/page.js
@@ -1,0 +1,53 @@
+export const dynamic = 'force-dynamic';
+
+import { connectDb } from '@/lib/db';
+import Accommodation from '@/models/accomodations';
+
+export default async function VersementPage() {
+  await connectDb();
+  const accommodations = await Accommodation.find().populate('owner').lean();
+
+  const rows = accommodations
+    .filter((a) => a.etat && a.etat.startsWith('Activé'))
+    .map((a) => ({
+      ownerId: a.owner?.id || '',
+      nomProprietaire: a.nomProprietaire || `${a.owner?.prenom || ''} ${a.owner?.nom || ''}`.trim(),
+      logement: a.logement,
+      adresse: [a.numero, a.adresse].filter(Boolean).join(' '),
+      codePostal: a.codePostal,
+      numeroRegistreTouristique: a.numeroRegistreTouristique || '',
+      classement: a.numeroRegistreTouristique ? 'Classé' : 'Non classé',
+    }));
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Logements à reverser</h1>
+      <table className="min-w-full border text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-2 py-1">ownerId</th>
+            <th className="border px-2 py-1">Nom propriétaire</th>
+            <th className="border px-2 py-1">Logement</th>
+            <th className="border px-2 py-1">Adresse</th>
+            <th className="border px-2 py-1">Code postal</th>
+            <th className="border px-2 py-1">N° registre touristique</th>
+            <th className="border px-2 py-1">Classement</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="border px-2 py-1">{r.ownerId}</td>
+              <td className="border px-2 py-1">{r.nomProprietaire}</td>
+              <td className="border px-2 py-1">{r.logement}</td>
+              <td className="border px-2 py-1">{r.adresse}</td>
+              <td className="border px-2 py-1">{r.codePostal}</td>
+              <td className="border px-2 py-1">{r.numeroRegistreTouristique}</td>
+              <td className="border px-2 py-1">{r.classement}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dynamic versement page with table of accommodations
- link the new page in the site navigation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551a05dfbc832e861cc88c287b4a58