### PR TITLE
Update models and UI for future taxe import

### DIFF
--- a/app/logements/LogementManager.jsx
+++ b/app/logements/LogementManager.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 export default function LogementManager({ initialAccommodations }) {
   const [accommodations, setAccommodations] = useState(initialAccommodations);
-  const [form, setForm] = useState({ owner: '', logement: '', adresse: '', codePostal: '' });
+  const [form, setForm] = useState({ owner: '', logement: '', adresse: '', codePostal: '', localite: '' });
   const [editingId, setEditingId] = useState(null);
 
   const handleChange = (e) => {
@@ -11,7 +11,7 @@ export default function LogementManager({ initialAccommodations }) {
   };
 
   const resetForm = () => {
-    setForm({ owner: '', logement: '', adresse: '', codePostal: '' });
+    setForm({ owner: '', logement: '', adresse: '', codePostal: '', localite: '' });
     setEditingId(null);
   };
 
@@ -46,8 +46,6 @@ export default function LogementManager({ initialAccommodations }) {
       localite: a.localite || '',
     });
 
-    setForm({ owner: a.owner?._id || a.owner, logement: a.logement || '', adresse: a.adresse || '', codePostal: a.codePostal || '' });
-
   };
 
   const handleDelete = async (id) => {
@@ -66,6 +64,7 @@ export default function LogementManager({ initialAccommodations }) {
         <input name="logement" value={form.logement} onChange={handleChange} placeholder="logement" className="border p-1" />
         <input name="adresse" value={form.adresse} onChange={handleChange} placeholder="adresse" className="border p-1" />
         <input name="codePostal" value={form.codePostal} onChange={handleChange} placeholder="codePostal" className="border p-1" />
+        <input name="localite" value={form.localite} onChange={handleChange} placeholder="localite" className="border p-1" />
         <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
           {editingId ? 'Modifier' : 'Ajouter'}
         </button>
@@ -82,6 +81,7 @@ export default function LogementManager({ initialAccommodations }) {
             <th className="border px-2 py-1">Logement</th>
             <th className="border px-2 py-1">Adresse</th>
             <th className="border px-2 py-1">Code postal</th>
+            <th className="border px-2 py-1">Localité</th>
             <th className="border px-2 py-1">Actions</th>
           </tr>
         </thead>
@@ -92,6 +92,7 @@ export default function LogementManager({ initialAccommodations }) {
               <td className="border px-2 py-1">{a.logement}</td>
               <td className="border px-2 py-1">{a.adresse}</td>
               <td className="border px-2 py-1">{a.codePostal}</td>
+              <td className="border px-2 py-1">{a.localite}</td>
               <td className="border px-2 py-1 space-x-2">
                 <button type="button" className="text-blue-600" onClick={() => handleEdit(a)}>Edit</button>
                 <button type="button" className="text-red-600" onClick={() => handleDelete(a._id)}>Delete</button>

--- a/app/models/accomodations.js
+++ b/app/models/accomodations.js
@@ -25,6 +25,15 @@ const accommodationSchema = new mongoose.Schema({
   numeroRegistreTouristique: String,
   commentairesAdditionnels: String,
   referenceCadastrale: String,
+  // Champs fournis par le fichier taxeDeSejour (pas présents dans le CSV d'origine)
+  prixNuitee: Number,
+  sejourDuree: Number,
+  sejourPerception: String,
+  sejourDebut: Date,
+  nbPersonnes: Number,
+  nbNuitees: Number,
+  tarifUnitaireTaxe: Number,
+  montantTaxe: Number,
 }, {
   timestamps: true,
 });

--- a/app/models/owners.js
+++ b/app/models/owners.js
@@ -15,6 +15,8 @@ const ownerSchema = new mongoose.Schema({
   ville: { type: String, trim: true },
   localite: { type: String, trim: true },
   email: { type: String, lowercase: true, trim: true },
+  // Supporte la colonne "E-mail" du fichier CSV original
+  'E-mail': { type: String, lowercase: true, trim: true },
   telephone: { type: String, trim: true },
   siret: { type: String, trim: true },
   mandat: { type: String, trim: true },

--- a/app/taxe-de-sejour/page.js
+++ b/app/taxe-de-sejour/page.js
@@ -8,8 +8,10 @@ import CSVUploader from '@/components/CSVUploader';
 export default function ImportPage() {
   const [ownerFile, setOwnerFile] = useState(null);
   const [accomFile, setAccomFile] = useState(null);
+  const [taxFile, setTaxFile] = useState(null);
   const [ownerMsg, setOwnerMsg] = useState('');
   const [accomMsg, setAccomMsg] = useState('');
+  const [taxMsg, setTaxMsg] = useState('');
 
   const handleUpload = async (file, endpoint, setMsg) => {
     if (!file) {
@@ -80,6 +82,31 @@ export default function ImportPage() {
         </button>
         {accomMsg && (
           <p className="mt-2 text-sm text-blue-700">{accomMsg}</p>
+        )}
+      </div>
+
+      {/* 3. Taxes de séjour */}
+      <div>
+        <h2 className="text-xl font-semibold mb-2">3. Importer la taxe de séjour</h2>
+        <CSVUploader
+          id="tax-upload"
+          fileName={taxFile?.name}
+          onFileSelect={setTaxFile}
+        />
+        <button
+          onClick={() =>
+            handleUpload(
+              taxFile,
+              '/api/upload-taxes',
+              setTaxMsg
+            )
+          }
+          className="mt-4 px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+        >
+          Importer la taxe de séjour
+        </button>
+        {taxMsg && (
+          <p className="mt-2 text-sm text-purple-700">{taxMsg}</p>
         )}
       </div>
     </div>

--- a/app/versement/VersementByLocalite.jsx
+++ b/app/versement/VersementByLocalite.jsx
@@ -1,0 +1,26 @@
+'use client';
+import { useState } from 'react';
+import VersementTable from './VersementTable';
+
+export default function VersementByLocalite({ rows, localites }) {
+  const [selected, setSelected] = useState(localites[0] || '');
+
+  const filtered = rows.filter(r => !selected || r.localite === selected);
+
+  return (
+    <div>
+      <div className="mb-4 space-x-2">
+        {localites.map(loc => (
+          <button
+            key={loc}
+            onClick={() => setSelected(loc)}
+            className={`px-2 py-1 border rounded ${selected === loc ? 'bg-blue-500 text-white' : ''}`}
+          >
+            {loc}
+          </button>
+        ))}
+      </div>
+      <VersementTable rows={filtered} />
+    </div>
+  );
+}

--- a/app/versement/VersementTable.jsx
+++ b/app/versement/VersementTable.jsx
@@ -36,6 +36,13 @@ export default function VersementTable({ rows }) {
             <th className="border px-2 py-1">Code postal</th>
             <th className="border px-2 py-1">N° registre touristique</th>
             <th className="border px-2 py-1">Classement</th>
+            <th className="border px-2 py-1">Prix nuitée</th>
+            <th className="border px-2 py-1">Début séjour</th>
+            <th className="border px-2 py-1">Durée</th>
+            <th className="border px-2 py-1">Nb pers.</th>
+            <th className="border px-2 py-1">Nb nuitées</th>
+            <th className="border px-2 py-1">Tarif taxe</th>
+            <th className="border px-2 py-1">Montant taxe</th>
           </tr>
         </thead>
         <tbody>
@@ -50,6 +57,13 @@ export default function VersementTable({ rows }) {
               <td className="border px-2 py-1">{r.codePostal}</td>
               <td className="border px-2 py-1">{r.numeroRegistreTouristique}</td>
               <td className="border px-2 py-1">{r.classement}</td>
+              <td className="border px-2 py-1">{r.prixNuitee ?? ''}</td>
+              <td className="border px-2 py-1">{r.sejourDebut ? new Date(r.sejourDebut).toLocaleDateString() : ''}</td>
+              <td className="border px-2 py-1">{r.sejourDuree ?? ''}</td>
+              <td className="border px-2 py-1">{r.nbPersonnes ?? ''}</td>
+              <td className="border px-2 py-1">{r.nbNuitees ?? ''}</td>
+              <td className="border px-2 py-1">{r.tarifUnitaireTaxe ?? ''}</td>
+              <td className="border px-2 py-1">{r.montantTaxe ?? ''}</td>
             </tr>
           ))}
         </tbody>

--- a/app/versement/page.js
+++ b/app/versement/page.js
@@ -1,7 +1,7 @@
 // app/versement/page.js
 export const dynamic = 'force-dynamic';
 
-import VersementTable from './VersementTable';
+import VersementByLocalite from './VersementByLocalite';
 import { connectDb } from '../lib/db';
 import Accommodation from '../models/accomodations';
 
@@ -28,13 +28,22 @@ export default async function VersementPage() {
       codePostal: a.codePostal,
       numeroRegistreTouristique: a.numeroRegistreTouristique || '',
       classement: a.numeroRegistreTouristique ? 'Classé' : 'Non classé',
+      prixNuitee: a.prixNuitee,
+      sejourDebut: a.sejourDebut ? a.sejourDebut.toISOString() : null,
+      sejourDuree: a.sejourDuree,
+      nbPersonnes: a.nbPersonnes,
+      nbNuitees: a.nbNuitees,
+      tarifUnitaireTaxe: a.tarifUnitaireTaxe,
+      montantTaxe: a.montantTaxe,
     }));
+
+  const localites = [...new Set(rows.map(r => r.localite).filter(Boolean))];
 
   return (
     <div className="p-8">
       <h1 className="text-2xl font-bold mb-4">Logements à reverser</h1>
       {rows.length > 0 ? (
-        <VersementTable rows={rows} />
+        <VersementByLocalite rows={rows} localites={localites} />
       ) : (
         <p className="text-gray-600">Aucun logement activé à reverser.</p>
       )}


### PR DESCRIPTION
## Summary
- add `E-mail` field to owners schema
- extend accommodations schema with taxe-de-séjour data fields
- display localité in logement management interface
- add taxe import drop zone
- allow selecting localité in versement page and show extra tax columns

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b42b08c8832e9fefc7156db6e4b3