### PR TITLE
Handle accommodation fetch errors

### DIFF
--- a/app/logements/page.js
+++ b/app/logements/page.js
@@ -7,37 +7,47 @@ import Accommodation from '../models/accomodations';
 import LogementManager from './LogementManager';
 
 export default async function LogementsPage() {
-  // 1) Ensure DB is connected
-  await connectDb();
+  try {
+    // 1) Ensure DB is connected
+    await connectDb();
 
-  // 2) Fetch as plain JS objects
-  const raw = await Accommodation.find()
-    .populate('owner')
-    .lean();
+    // 2) Fetch as plain JS objects
+    const raw = await Accommodation.find()
+      .populate('owner')
+      .lean();
 
-  // 3) Convert ObjectIds and Dates into strings/ISO formats
-  const accommodations = raw.map(doc => ({
-    ...doc,
-    _id: doc._id.toString(),
-    localite: doc.localite,
-    ownerId: doc.owner ? doc.owner.id : null,
-    owner: doc.owner
-      ? {
-          ...doc.owner,
-          _id: doc.owner._id.toString(),
-          createdAt: doc.owner.createdAt.toISOString(),
-          updatedAt: doc.owner.updatedAt.toISOString(),
-        }
-      : null,
-    createdAt: doc.createdAt.toISOString(),
-    updatedAt: doc.updatedAt.toISOString(),
-  }));
+    // 3) Convert ObjectIds and Dates into strings/ISO formats
+    const accommodations = raw.map(doc => ({
+      ...doc,
+      _id: doc._id.toString(),
+      localite: doc.localite,
+      ownerId: doc.owner ? doc.owner.id : null,
+      owner: doc.owner
+        ? {
+            ...doc.owner,
+            _id: doc.owner._id.toString(),
+            createdAt: doc.owner.createdAt.toISOString(),
+            updatedAt: doc.owner.updatedAt.toISOString(),
+          }
+        : null,
+      createdAt: doc.createdAt.toISOString(),
+      updatedAt: doc.updatedAt.toISOString(),
+    }));
 
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Gestion des logements</h1>
-      {/* Now safe to pass only plain JS objects */}
-      <LogementManager initialAccommodations={accommodations} />
-    </div>
-  );
+    return (
+      <div className="p-8">
+        <h1 className="text-2xl font-bold mb-4">Gestion des logements</h1>
+        {/* Now safe to pass only plain JS objects */}
+        <LogementManager initialAccommodations={accommodations} />
+      </div>
+    );
+  } catch (err) {
+    console.error('[logements] Error fetching accommodations:', err);
+    return (
+      <div className="p-8">
+        <h1 className="text-2xl font-bold mb-4">Gestion des logements</h1>
+        <p className="text-red-600">Impossible de récupérer les logements.</p>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add error handling in logement page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867183fee40832ea3b01bd81ccc058a